### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -189,7 +189,7 @@ dependencies:
   - multipledispatch=0.6.0=py37_0
   - multiqc=1.7=py_4
   - nbconvert=5.4.1=py37_3
-  - nbformat=4.4.0=py37_0
+  - nbformat=5.0
   - ncurses=6.1=he6710b0_1
   - networkx=2.2=py37_1
   - nltk=3.4=py37_1
@@ -249,7 +249,7 @@ dependencies:
   - pycrypto=2.6.1=py37h14c3975_9
   - pycurl=7.43.0.2=py37h1ba5d50_0
   - pyflakes=2.1.1=py37_0
-  - pygments=2.4.1=py37_0
+  - pygments=2.4.1
   - pylint=2.3.1=py37_0
   - pymysql=0.9.3=py37_0
   - pynacl=1.3.0=py37h7b6447c_0


### PR DESCRIPTION
nothing provides requested pygments ==2.4.1 py37_0
package nbclient-0.5.4-pyhd8ed1ab_0 requires nbformat >=5.0, but none of the providers can be installed